### PR TITLE
Add basic CI workflow (Github Actions)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  raku:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        raku-version:
+          - "latest"
+          - "2023.08"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ matrix.raku-version }}
+      - name: Run tests and Install
+        run: zef install . --debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,6 @@ jobs:
         with:
           raku-version: ${{ matrix.raku-version }}
       - name: Run tests and Install
+        env:
+          ZEF_EXTRACT_TIMEOUT: 0
         run: zef install . --debug


### PR DESCRIPTION
Hi,

I came across this recent Raku library and saw it had no CI so I took one that I tend to use following the advice of the developer of zef.

As you can see, it works nicely on both Rakudo releases with Ubuntu and Mac but Windows is troublesome again. The problematic nature of Windows tests is known but on the latest Rakudo, it even seemed like a non-deterministic failure. Of course Windows could be removed from the test matrics and then a "passing" badge could be obtained - I would leave that part to you.