### PR TITLE
Replacing JSON::Tiny with JSON::Fast

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -227,7 +227,7 @@
     "WebDriver2::Until::SUT" : "lib/WebDriver2/Until/SUT.rakumod"
   },
   "depends" : [
-    "JSON::Tiny",
+    "JSON::Fast",
     "URI::Encode",
     "HTTP::Status",
     "File::Temp",

--- a/lib/WebDriver2/Command.rakumod
+++ b/lib/WebDriver2/Command.rakumod
@@ -1,4 +1,4 @@
-use JSON::Tiny;
+use JSON::Fast;
 use WebDriver2::HTTP::Response;
 use WebDriver2;
 

--- a/lib/WebDriver2/Command/Result/Factory.rakumod
+++ b/lib/WebDriver2/Command/Result/Factory.rakumod
@@ -1,4 +1,4 @@
-use JSON::Tiny;
+use JSON::Fast;
 
 use WebDriver2::HTTP::Response;
 

--- a/lib/WebDriver2/Command/Result/Factory/Chromium.rakumod
+++ b/lib/WebDriver2/Command/Result/Factory/Chromium.rakumod
@@ -1,4 +1,4 @@
-use JSON::Tiny;
+use JSON::Fast;
 
 #use WebDriver2;
 use WebDriver2::Command::Execution-Status;

--- a/lib/WebDriver2/Command/Result/Factory/Edge.rakumod
+++ b/lib/WebDriver2/Command/Result/Factory/Edge.rakumod
@@ -1,5 +1,5 @@
 #use WebDriver2::HTTP::Response;
-#use JSON::Tiny;
+#use JSON::Fast;
 #
 #use WebDriver2;
 #use WebDriver2::Constants;

--- a/lib/WebDriver2/Command/Result/Factory/Firefox.rakumod
+++ b/lib/WebDriver2/Command/Result/Factory/Firefox.rakumod
@@ -1,5 +1,5 @@
 use WebDriver2::HTTP::Response;
-use JSON::Tiny;
+use JSON::Fast;
 
 #use WebDriver2;
 use WebDriver2::Command::Execution-Status;

--- a/lib/WebDriver2/Command/Result/Factory/Safari.rakumod
+++ b/lib/WebDriver2/Command/Result/Factory/Safari.rakumod
@@ -1,5 +1,5 @@
 use WebDriver2::HTTP::Response;
-use JSON::Tiny;
+use JSON::Fast;
 
 use WebDriver2::Command::Execution-Status;
 use WebDriver2::Command::Result;

--- a/lib/WebDriver2/Driver.rakumod
+++ b/lib/WebDriver2/Driver.rakumod
@@ -1,7 +1,7 @@
 use WebDriver2::HTTP::UserAgent;
 use WebDriver2::HTTP::Message;
 use WebDriver2::HTTP::Request;
-use JSON::Tiny;
+use JSON::Fast;
 use URI::Encode;
 use WebDriver2::Driver::Server;
 use WebDriver2;

--- a/lib/WebDriver2/Driver/Edge.rakumod
+++ b/lib/WebDriver2/Driver/Edge.rakumod
@@ -1,6 +1,6 @@
 use WebDriver2::HTTP::UserAgent;
 use WebDriver2::HTTP::Request;
-use JSON::Tiny;
+use JSON::Fast;
 use URI::Encode;
 use WebDriver2::Driver::Server;
 use WebDriver2;

--- a/lib/WebDriver2/Driver/Firefox.rakumod
+++ b/lib/WebDriver2/Driver/Firefox.rakumod
@@ -1,6 +1,6 @@
 use WebDriver2::HTTP::UserAgent;
 use WebDriver2::HTTP::Request;
-use JSON::Tiny;
+use JSON::Fast;
 use URI::Encode;
 use WebDriver2::Driver::Server;
 use WebDriver2;

--- a/lib/WebDriver2/Driver/Safari.rakumod
+++ b/lib/WebDriver2/Driver/Safari.rakumod
@@ -1,6 +1,6 @@
 use WebDriver2::HTTP::UserAgent;
 use WebDriver2::HTTP::Request;
-use JSON::Tiny;
+use JSON::Fast;
 use URI::Encode;
 use WebDriver2::Driver::Server;
 use WebDriver2;


### PR DESCRIPTION
JSON::Tiny has barely been maintained for years while JSON::Fast is extensively used and co-developed by several core contributors. Actually, this project has already depended on JSON::Fast, transitively. This change is supposed to simply be a step towards good practices.